### PR TITLE
Fix parsing error

### DIFF
--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -19,6 +19,10 @@ Plugin.prototype.register = function (name, plugin) {
 }
 
 Plugin.prototype.parse = function (state) {
+	if (state.src.charCodeAt(state.pos) !== 123) {
+        	return false
+    	}
+
 	var match = this.reg.exec(state.src.slice(state.pos))
 	if (!match) return false
 


### PR DESCRIPTION
Currently rendering fails if the embedment is inline and it causes a lot of issues.

```
Some paragraph {@youtube: abcdef}
^              ^
1              2 
```

1. `state.pos` before fix
2. required `state.pos` to make replacement correctly (match must be run only when start sequence found)