### PR TITLE
Allow for parameters in the tag

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+*~
+*-
+.*.sw?
+yarn.lock
+*.test.*
+tonic.js
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+- 8.9.4
+deploy:
+  provider: npm
+  email: wt3kd893td@bytes.nz
+  on:
+    branch: master
+  api_key:
+    secure: lo0FCt58XteOyGrBI9txahvlw2pTzULo73l9dJ+skGLz6OB6YtOjHU2UcAStxreaPpMTblxuCuRqGCtIGvhUjkvv3l+EhpxzWtNFZfkN+HeoxvRFktVv/xAd9rmYiLq4jyK/qas6sykdh22cKbNOAF+Gz5W+8tgcod1lNLsysJJrYsbrnTw1kUCBI8wjVsbBN9GBUnVYQchTUq6OHaridkKeKiQl5RH2M4YfodbrrgpoMmYCHVgtbMkLlsc9MwZ2GyQAqS2s/BuHf0N9Mtw4U3mal/YsB9vvh1fpsV7F1Oojj0T5X/kRfVNIweC97YMrf4Ck3dFnyJVD4Hu53z+itp5MZMyFdH4OzFA/uzRPp6A05se7YEyC+ORrKhDeWRSR9yjQlKw7GV4CSYspXoTKBXHv8bj1KBf026XHvGfisQcDXBvLJeIuEz05U2x+vF9a0dZVmbQBZ6/EVaNGZeQEeCmkFIu5CXk2IQaHoXOCJ2PAbSGDnjOTc6pf+tGOr17b42P46zUlINpjAO95HQ0bslrLgDgCIoRAm3iKO+z03Tiem65lW8rLs1fzgPI84ErhW/6bm7WivwCEkazijWOVT5heRGKOhdq4qM1+NkuiCwL6JSBFaPKQPPSN2Vwv6eZMJiaoNHgjsllvAfIh66lAE4znkTgSAzVXo5y8749ZSmE=

--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
-# remarkable-embed
+# remarkably-simple-tags
 
-Provides the `{@plugin: slug}` and `{@plugin: parameter1[ parameter2...]}` syntaxes to remarkable,
-allowing you to embed rich content in your documents as defined by any given plugins.
+Provides the `{@plugin: parameters}` syntax to remarkable, allowing you to
+easily create your own tags including tags to embed rich content in your
+documents as defined by any given plugins.
 
-See '[remarkable-embed tonic](https://tonicdev.com/npm/remarkable-embed)' to try it in your browser
+Forked from
+[remarkable-embeded](https://github.com/Commander-lol/remarkable-embed).
+Credits to [Commander-lol](https://github.com/Commander-lol) for most
+of the code
 
-By default `remarkable-embed` comes with two plugins: One for [youtube](https://youtube.com) videos and one for [codepen.io](https://codepen.io) pens.
+Try in your browser with
+[tonic](https://tonicdev.com/npm/remarkably-simple-tags)
 
-Creating new plugins is also super simple - The Youtube plugin showcases a straight forward embed and the Codepen plugin showcases usage of the `remarkable` options object
+By default `remarkably-simple-tags` comes with two plugins: One for
+[youtube](https://youtube.com) videos and one for
+[codepen.io](https://codepen.io) pens.
+
+Creating new plugins is also super simple - The Youtube plugin showcases a
+straight forward embed and the Codepen plugin showcases usage of the
+`remarkable` options object
 
 ## Installation
-`npm install --save remarkable-embed`
+`npm install --save remarkably-simple-tags`
 
 ## Usage - Code
 
@@ -18,39 +29,43 @@ _This module is not built with transpiled/es6, but the examples are simpler with
 
 ```javascript
 import Remarkable from 'remarkable';
-import { Plugin as Embed, extensions } from 'remarkable-embed';
+import { Plugin as RST, extensions } from 'remarkably-simple-tags';
 
 const md = new Remarkable()
 
-const embed = new Embed()
-embed.register('youtube', extensions.youtube)
+const rst = new RST()
+rst.register('youtube', extensions.youtube)
 
-md.use(embed.hook)
+md.use(rst.hook)
 md.render('This vid is gr8 m8 {@youtube: dQw4w9WgXcQ}')
 
 // Output: '<p>This vid is gr8 m8 </p><iframe type="text/html" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0"></iframe>'
 ```
 
-Plugins can also be registered by passing an object to `Embed#register()`, in which case they will all
-be registered by the key in the object.
+Plugins can also be registered by passing an object to `Embed#register()`,
+in which case they will all be registered by the key in the object.
 
 ```javascript
-embed.register({
+rst.register({
   youtube: extensions.youtube
 })
 ```
 
-The `extensions` object provided alongside `remarkable-embed` can also be passed directly to register to use
-all of the built in extensions.
+The `extensions` object provided alongside `remarkably-simple-tags` can also
+be passed directly to register to use all of the built in extensions.
 
 ```javascript
-embed.register(extensions)
+rst.register(extensions)
 ```
 
 ## Usage - Markdown
-Plugins extend the markdown syntax by adding constructs of the form `{@[name]: [meta]}`, where `[name]`
-is the name used to register the plugin with `remarkable-embed` and `[meta]` is the information that will
-be passed to the plugin. The example youtube extension takes either the full embed link or the video id.
+Plugins extend the markdown syntax by adding constructs of the form
+`{[name: parameter[ parameters...]}`, where `name` is the name used to
+register the plugin with `remarkably-simple-tags` and `parameter(s)` is the
+space-separated information that will be passed to the plugin. Parameters can
+be quoteed to include spaces and quotes and curly braces should be escaped
+with \\. The example youtube extension takes either the full embed link or
+the video id.
 
 ## Extensions - Built in
 
@@ -60,13 +75,17 @@ be passed to the plugin. The example youtube extension takes either the full emb
  - Full embed link (e.g. `https://www.youtube.com/embed/wsQGwDy1lvg`)
 
 ## Extensions - Creating
-A `remarkable-embed` plugin is a simple function with the signature `plugin(meta[, opts])` where `meta` is the arbitrary
-string that doesn't contains whitespace captured by the markdown tag, and options is the options object that was passed to the `Remarkable` parser when it was created
+A `remarkable-embed` plugin is a simple function with the signature
+`plugin(parameters[, opts])` where `parameters` is and array of the parameters
+separated by whitespace captured by the markdown tag, and options is the
+options object that was passed to the `Remarkable` parser when it was created.
 
-If your plugin requires multiple parameters, pass `true` as the second parameter when
-registering the plugin.
+If your plugin is built for remarkable-embed, pass `true` as the third
+parameter when registering the plugin.
 ```javascript
-embed.register('mytag', myplugin, true);
+const myplugin = (slug, opts) => {
+  return 'Something cool: ' + slug;
+};
+
+rst.register('mytag', myplugin, true);
 ```
-Plugins registered this way instead of receiving a slug string will receive an array of parameters
-captured by the markdown tag that were separated by spaces.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # remarkably-simple-tags
 
-Provides the `{@plugin: parameters}` syntax to remarkable, allowing you to
-easily create your own tags including tags to embed rich content in your
-documents as defined by any given plugins.
+Provides the `{@plugin[: parameters [parameters...]]}` syntax to remarkable,
+allowing you to easily create your own tags including tags to embed rich
+content in your documents as defined by any given plugins.
 
 Forked from
 [remarkable-embeded](https://github.com/Commander-lol/remarkable-embed).
@@ -60,7 +60,7 @@ rst.register(extensions)
 
 ## Usage - Markdown
 Plugins extend the markdown syntax by adding constructs of the form
-`{[name: parameter[ parameters...]}`, where `name` is the name used to
+`{[name[: parameter[ parameters...]]}`, where `name` is the name used to
 register the plugin with `remarkably-simple-tags` and `parameter(s)` is the
 space-separated information that will be passed to the plugin. Parameters can
 be quoteed to include spaces and quotes and curly braces should be escaped

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # remarkable-embed
 
-Provides the `{@plugin: slug}` syntax to remarkable, allowing you to embed rich content in your documents as defined
-by any given plugins.
+Provides the `{@plugin: slug}` and `{@plugin: parameter1[ parameter2...]}` syntaxes to remarkable,
+allowing you to embed rich content in your documents as defined by any given plugins.
 
 See '[remarkable-embed tonic](https://tonicdev.com/npm/remarkable-embed)' to try it in your browser
 
@@ -48,7 +48,7 @@ embed.register(extensions)
 ```
 
 ## Usage - Markdown
-Plugins extend the markdown syntax by adding constructs of the form `{@[name]: [meta]}`, where `[name]` 
+Plugins extend the markdown syntax by adding constructs of the form `{@[name]: [meta]}`, where `[name]`
 is the name used to register the plugin with `remarkable-embed` and `[meta]` is the information that will
 be passed to the plugin. The example youtube extension takes either the full embed link or the video id.
 
@@ -62,3 +62,11 @@ be passed to the plugin. The example youtube extension takes either the full emb
 ## Extensions - Creating
 A `remarkable-embed` plugin is a simple function with the signature `plugin(meta[, opts])` where `meta` is the arbitrary
 string that doesn't contains whitespace captured by the markdown tag, and options is the options object that was passed to the `Remarkable` parser when it was created
+
+If your plugin requires multiple parameters, pass `true` as the second parameter when
+registering the plugin.
+```javascript
+embed.register('mytag', myplugin, true);
+```
+Plugins registered this way instead of receiving a slug string will receive an array of parameters
+captured by the markdown tag that were separated by spaces.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # remarkably-simple-tags
 
+[![Build Status](https://travis-ci.org/bytesnz/remarkably-simple-tags.svg?branch=master)](https://travis-ci.org/bytesnz/remarkably-simple-tags)
+
 Provides the `{@plugin[: parameters [parameters...]]}` syntax to remarkable,
 allowing you to easily create your own tags including tags to embed rich
 content in your documents as defined by any given plugins.

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -50,6 +50,7 @@ Plugin.prototype.extractTags = function (state) {
       case '\\': // Skip escaped character
         parameter += state.src[state.pos+1];
         state.pos += 2;
+        break;
       case '{':
         tag = this.extractTags(state);
 
@@ -84,6 +85,11 @@ Plugin.prototype.extractTags = function (state) {
         break;
       case ' ':
         if (!quote) {
+          // Ignore multiple spaces
+          if (state.src[state.pos-1] === ' ') {
+            state.pos++;
+            break;
+          }
           if (tagContainer) {
             tagContainer.push(parameter);
             parameters.push(tagContainer);

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -1,6 +1,6 @@
 function Plugin() {
   this.id = 'at-embed';
-  this.reg = /({@(\w+)\s*:\s*)([^}]+?)}/;
+  this.reg = /({@(\w+)(\s*:\s*)?)([^}]*)}/;
   this.plugins = {};
   this.hook = (function (self) {
     self.inline.ruler.push(this.id, this.parse.bind(this));
@@ -38,6 +38,11 @@ Plugin.prototype.extractTags = function (state) {
   var tag;
 
   state.pos += match[1].length;
+
+  if (typeof match[3] === 'undefined' && match[4] === '') {
+    state.pos += 1;
+    return parameters;
+  }
 
   // Parse parameters
   while(state.pos < state.src.length) {

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -1,6 +1,6 @@
 function Plugin() {
   this.id = 'at-embed';
-  this.reg = /({@(\w+)\s*:\s*)([^}]+?)}/;
+  this.reg = /({@(\w+)(\s*:\s*)?)([^}]+?)}/;
   this.plugins = {};
   this.hook = (function (self) {
     self.inline.ruler.push(this.id, this.parse.bind(this));
@@ -9,16 +9,16 @@ function Plugin() {
   return this;
 }
 
-Plugin.prototype.register = function (name, plugin, multiple) {
+Plugin.prototype.register = function (name, plugin, single) {
   if (typeof(name) === 'string') {
     this.plugins[name] = plugin;
-    if (multiple) {
-      this.plugins[name].multiple = true;
+    if (single) {
+      this.plugins[name].single = true;
     }
   } else {
-    if (multiple) {
+    if (single) {
       Object.keys(name).forEach(function (key) {
-        name[key].mulitple = true;
+        name[key].single = true;
       });
     }
 
@@ -150,11 +150,11 @@ Plugin.prototype.renderTags = function (parts, opts) {
     return '{@' + tag + ': ' + parts.join(' ') + '}';
   }
 
-  if (this.plugins[tag].multiple) {
-    return this.plugins[tag](parts, opts);
-  } else {
+  if (this.plugins[tag].single) {
     return this.plugins[tag](parts[0], opts);
   }
+
+  return this.plugins[tag](parts, opts);
 }
 
 Plugin.prototype.render = function (tokens, idx, opts) {

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -1,6 +1,6 @@
 function Plugin() {
-	this.id = 'at-embed';
-	this.reg = /{@(\w+)\s*:\s*([\S]+?)}/;
+	this.id = 'rst';
+	this.reg = /{@(\w+)\s*:\s*([^}]+?)}/;
 	this.plugins = {};
 	this.hook = (function (self) {
 		self.inline.ruler.push(this.id, this.parse.bind(this));
@@ -29,12 +29,23 @@ Plugin.prototype.parse = function (state) {
 	// valid match found, now we need to advance cursor
 	state.pos += match[0].length
 
+  const meta = match[2].match(/\\?.|^$/g).reduce((p, c) => {
+    if(c === '"') {
+      p.quote ^= 1;
+    } else if(!p.quote && c === ' ') {
+      p.a.push('');
+    } else {
+      p.a[p.a.length-1] += c.replace(/\\(.)/,"$1");
+    }
+    return  p;
+  }, {a: ['']}).a;
+
 	var token = {
 		type: this.id,
 		level: state.level,
 		content: {
 			plugin: match[1],
-			meta: match[2],
+			meta: meta,
 			match: match
 		},
 	};

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -1,33 +1,33 @@
 function Plugin() {
-	this.id = 'rst';
-	this.reg = /{@(\w+)\s*:\s*([^}]+?)}/;
-	this.plugins = {};
-	this.hook = (function (self) {
-		self.inline.ruler.push(this.id, this.parse.bind(this));
-		self.renderer.rules[this.id] = this.render.bind(this);
-	}).bind(this)
-	return this;
+  this.id = 'at-embed';
+  this.reg = /({@(\w+)\s*:\s*)([^}]+?)}/;
+  this.plugins = {};
+  this.hook = (function (self) {
+    self.inline.ruler.push(this.id, this.parse.bind(this));
+    self.renderer.rules[this.id] = this.render.bind(this);
+  }).bind(this)
+  return this;
 }
 
 Plugin.prototype.register = function (name, plugin) {
-	if (typeof(name) === 'string') {
-		this.plugins[name] = plugin;
-	} else {
-		// Name is actually an object of {name: plugin} pairs
-		Object.assign(this.plugins, name);
-	}
+  if (typeof(name) === 'string') {
+    this.plugins[name] = plugin;
+  } else {
+    // Name is actually an object of {name: plugin} pairs
+    Object.assign(this.plugins, name);
+  }
 }
 
 Plugin.prototype.parse = function (state) {
-	if (state.src.charCodeAt(state.pos) !== 123) {
-        	return false
-    	}
+  if (state.src.charCodeAt(state.pos) !== 123) {
+          return false
+      }
 
-	var match = this.reg.exec(state.src.slice(state.pos))
-	if (!match) return false
+  var match = this.reg.exec(state.src.slice(state.pos))
+  if (!match) return false
 
-	// valid match found, now we need to advance cursor
-	state.pos += match[0].length
+  // valid match found, now we need to advance cursor
+  state.pos += match[0].length
 
   const meta = match[2].match(/\\?.|^$/g).reduce((p, c) => {
     if(c === '"') {
@@ -40,29 +40,29 @@ Plugin.prototype.parse = function (state) {
     return  p;
   }, {a: ['']}).a;
 
-	var token = {
-		type: this.id,
-		level: state.level,
-		content: {
-			plugin: match[1],
-			meta: meta,
-			match: match
-		},
-	};
+  var token = {
+    type: this.id,
+    level: state.level,
+    content: {
+      plugin: match[1],
+      meta: meta,
+      match: match
+    },
+  };
 
-	state.push(token);
-	return true;
+  state.push(token);
+  return true;
 }
 
 Plugin.prototype.render = function (tokens, idx, opts) {
-	var token = tokens[idx]
-	var plugin = token.content.plugin
-	var meta = token.content.meta
+  var token = tokens[idx]
+  var plugin = token.content.plugin
+  var meta = token.content.meta
 
-	if (!this.plugins.hasOwnProperty(plugin)) {
-		return meta
-	}
-	return this.plugins[plugin](meta, opts)
+  if (!this.plugins.hasOwnProperty(plugin)) {
+    return meta
+  }
+  return this.plugins[plugin](meta, opts)
 }
 
 module.exports = Plugin;

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -18,51 +18,136 @@ Plugin.prototype.register = function (name, plugin) {
   }
 }
 
+Plugin.prototype.extractTags = function (state) {
+  var match = this.reg.exec(state.src.slice(state.pos))
+  if (!match) return false;
+
+  var parameters = [match[2]];
+  var quote = false;
+  var tagContainer = null;
+  var parameter = '';
+  var tag;
+
+  state.pos += match[1].length;
+
+  // Parse parameters
+  while(state.pos < state.src.length) {
+    switch (state.src[state.pos]) {
+      case '\\': // Skip escaped character
+        parameter += state.src[state.pos+1];
+        state.pos += 2;
+      case '{':
+        tag = this.extractTags(state);
+
+        if (!tag) {
+          parameter += '{';
+          state.pos++;
+          break;
+        } else {
+          if (tagContainer) {
+            tagContainer.push(parameter, tag);
+          } else {
+            tagContainer = [
+              parameter,
+              tag
+            ];
+          }
+          parameter = '';
+        }
+        break;
+      case '}': // Finish tag
+        if (tagContainer) {
+          tagContainer.push(parameter);
+          parameters.push(tagContainer);
+        } else {
+          parameters.push(parameter);
+        }
+        state.pos++;
+        return parameters;
+      case '"':
+        quote = !quote;
+        state.pos++
+        break;
+      case ' ':
+        if (!quote) {
+          if (tagContainer) {
+            tagContainer.push(parameter);
+            parameters.push(tagContainer);
+            tagContainer = null;
+          } else {
+            parameters.push(parameter);
+          }
+          parameter = '';
+          state.pos++;
+          break;
+        }
+      default:
+        parameter += state.src[state.pos];
+        state.pos++;
+    }
+  }
+
+  parameters.push(parameter);
+  return parameters;
+}
+
+
+
 Plugin.prototype.parse = function (state) {
   if (state.src.charCodeAt(state.pos) !== 123) {
-          return false
-      }
+    return false
+  }
 
-  var match = this.reg.exec(state.src.slice(state.pos))
-  if (!match) return false
+  var parts = this.extractTags(state);
 
-  // valid match found, now we need to advance cursor
-  state.pos += match[0].length
-
-  const meta = match[2].match(/\\?.|^$/g).reduce((p, c) => {
-    if(c === '"') {
-      p.quote ^= 1;
-    } else if(!p.quote && c === ' ') {
-      p.a.push('');
-    } else {
-      p.a[p.a.length-1] += c.replace(/\\(.)/,"$1");
-    }
-    return  p;
-  }, {a: ['']}).a;
+  if (!parts) {
+    return false;
+  }
 
   var token = {
     type: this.id,
     level: state.level,
-    content: {
-      plugin: match[1],
-      meta: meta,
-      match: match
-    },
+    content: parts,
   };
 
   state.push(token);
   return true;
 }
 
-Plugin.prototype.render = function (tokens, idx, opts) {
-  var token = tokens[idx]
-  var plugin = token.content.plugin
-  var meta = token.content.meta
+Plugin.prototype.renderTags = function (parts, opts) {
+  var tag = parts.shift();
 
-  if (!this.plugins.hasOwnProperty(plugin)) {
-    return meta
+  // Check for tags inside base tag
+  parts = parts.map((part) => {
+    if (Array.isArray(part)) {
+      var pre = part.shift();
+      var post = part.pop();
+
+      part = part.map((subPart) => {
+        if (Array.isArray(subPart)) {
+          return this.renderTags(subPart, opts);
+        }
+
+        return subPart;
+      });
+
+      return pre + part.join('') + post;
+    }
+
+    return part;
+  });
+
+  if (!this.plugins.hasOwnProperty(tag)) {
+    return '{@' + tag + ': ' + parts.join(' ') + '}';
   }
-  return this.plugins[plugin](meta, opts)
+
+  return this.plugins[tag](parts, opts);
+}
+
+Plugin.prototype.render = function (tokens, idx, opts) {
+  var token = tokens[idx];
+
+  return this.renderTags(token.content, opts);
 }
 
 module.exports = Plugin;

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -1,6 +1,6 @@
 function Plugin() {
   this.id = 'at-embed';
-  this.reg = /({@(\w+)(\s*:\s*)?)([^}]+?)}/;
+  this.reg = /({@(\w+)\s*:\s*)([^}]+?)}/;
   this.plugins = {};
   this.hook = (function (self) {
     self.inline.ruler.push(this.id, this.parse.bind(this));

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -9,10 +9,19 @@ function Plugin() {
   return this;
 }
 
-Plugin.prototype.register = function (name, plugin) {
+Plugin.prototype.register = function (name, plugin, multiple) {
   if (typeof(name) === 'string') {
     this.plugins[name] = plugin;
+    if (multiple) {
+      this.plugins[name].multiple = true;
+    }
   } else {
+    if (multiple) {
+      Object.keys(name).forEach(function (key) {
+        name[key].mulitple = true;
+      });
+    }
+
     // Name is actually an object of {name: plugin} pairs
     Object.assign(this.plugins, name);
   }
@@ -141,7 +150,11 @@ Plugin.prototype.renderTags = function (parts, opts) {
     return '{@' + tag + ': ' + parts.join(' ') + '}';
   }
 
-  return this.plugins[tag](parts, opts);
+  if (this.plugins[tag].multiple) {
+    return this.plugins[tag](parts, opts);
+  } else {
+    return this.plugins[tag](parts[0], opts);
+  }
 }
 
 Plugin.prototype.render = function (tokens, idx, opts) {

--- a/lib/Plugin.test.js
+++ b/lib/Plugin.test.js
@@ -1,4 +1,5 @@
 const test = require('ava');
+const Remarkable = require('remarkable');
 
 const Plugin = require('./Plugin');
 
@@ -12,6 +13,8 @@ test.beforeEach((t) => {
     t.context.opts.push(opts);
     return 'TEST(' + parameters.join(',') + ')';
   });
+
+  t.context.md = new Remarkable();
 });
 
 test('parse() set pos to character after end of tag and returns true', (t) => {
@@ -109,7 +112,7 @@ test('render() calls the plugins in plugins', (t) => {
   t.is(opts, t.context.opts[0], 'opts was not passed to the plugin');
 });
 
-test('Plugin works for old slug plugins when given single option', (t) => {
+test('RST works for old slug plugins when given single option', (t) => {
   let calls = 0;
   const state = [];
   state.src = '{@slug: aslug}';
@@ -134,7 +137,7 @@ test('Plugin works for old slug plugins when given single option', (t) => {
   t.is('SLUG(aslug)', result, 'Rendered result was not as expected');
 });
 
-test('Plugin works for new parameter plugins', (t) => {
+test('RST works for new parameter plugins', (t) => {
   const state = [];
   state.src = '{@test: this is cool}';
   state.pos = 0;
@@ -149,4 +152,17 @@ test('Plugin works for new parameter plugins', (t) => {
   t.is(1, t.context.calls, 'The plugin function was not called');
   t.is(opts, t.context.opts[0], 'The opts were not passed to the plugin');
   t.is('TEST(this,is,cool)', result, 'Rendered result was not as expected');
+});
+
+test ('RST can be used with Remarkable', (t) => {
+  t.context.md.use(t.context.plugin.hook);
+  t.pass();
+});
+
+test('RST works with Remarkable', (t) => {
+  t.context.md.use(t.context.plugin.hook);
+
+  const result = t.context.md.render('string{@test:hello}end');
+
+  t.is('<p>stringTEST(hello)end</p>\n', result);
 });

--- a/lib/Plugin.test.js
+++ b/lib/Plugin.test.js
@@ -11,7 +11,7 @@ test.beforeEach((t) => {
     t.context.calls++;
     t.context.opts.push(opts);
     return 'TEST(' + parameters.join(',') + ')';
-  }, true);
+  });
 });
 
 test('parse() set pos to character after end of tag and returns true', (t) => {
@@ -109,7 +109,7 @@ test('render() calls the plugins in plugins', (t) => {
   t.is(opts, t.context.opts[0], 'opts was not passed to the plugin');
 });
 
-test('Plugin works for old slug plugins', (t) => {
+test('Plugin works for old slug plugins when given single option', (t) => {
   let calls = 0;
   const state = [];
   state.src = '{@slug: aslug}';
@@ -121,7 +121,7 @@ test('Plugin works for old slug plugins', (t) => {
     calls++;
     givenOpts = opts;
     return 'SLUG(' + slug + ')';
-  });
+  }, true);
 
   t.context.plugin.parse(state);
 

--- a/lib/Plugin.test.js
+++ b/lib/Plugin.test.js
@@ -11,7 +11,7 @@ test.beforeEach((t) => {
     t.context.calls++;
     t.context.opts.push(opts);
     return 'TEST(' + parameters.join(',') + ')';
-  });
+  }, true);
 });
 
 test('parse() set pos to character after end of tag and returns true', (t) => {
@@ -23,6 +23,7 @@ test('parse() set pos to character after end of tag and returns true', (t) => {
 
   t.is(state.src.indexOf('}') + 1, state.pos, 'did not set the pos to the character after the tag');
   t.is(true, result, 'did not return true');
+  t.is(1, state.length, 'One tag did not get added to the state');
 });
 
 test('parse() does not change the position and returns false if it is not a tag', (t) => {
@@ -106,4 +107,46 @@ test('render() calls the plugins in plugins', (t) => {
   t.is(2, t.context.calls, 'plugin was not called once');
   t.is('TEST(frogTEST(awesome)end,ok)', result, 'rendered string was not as it should be');
   t.is(opts, t.context.opts[0], 'opts was not passed to the plugin');
+});
+
+test('Plugin works for old slug plugins', (t) => {
+  let calls = 0;
+  const state = [];
+  state.src = '{@slug: aslug}';
+  state.pos = 0;
+  const opts = {};
+  let givenOpts;
+
+  t.context.plugin.register('slug', (slug, opts) => {
+    calls++;
+    givenOpts = opts;
+    return 'SLUG(' + slug + ')';
+  });
+
+  t.context.plugin.parse(state);
+
+  t.is(1, state.length, 'One tag did not get added to the state');
+
+  const result = t.context.plugin.render(state, 0, opts);
+
+  t.is(1, calls, 'The plugin function was not called');
+  t.is(opts, givenOpts, 'The opts were not passed to the plugin');
+  t.is('SLUG(aslug)', result, 'Rendered result was not as expected');
+});
+
+test('Plugin works for new parameter plugins', (t) => {
+  const state = [];
+  state.src = '{@test: this is cool}';
+  state.pos = 0;
+  const opts = {};
+
+  t.context.plugin.parse(state);
+
+  t.is(1, state.length, 'One tag did not get added to the state');
+
+  const result = t.context.plugin.render(state, 0, opts);
+
+  t.is(1, t.context.calls, 'The plugin function was not called');
+  t.is(opts, t.context.opts[0], 'The opts were not passed to the plugin');
+  t.is('TEST(this,is,cool)', result, 'Rendered result was not as expected');
 });

--- a/lib/Plugin.test.js
+++ b/lib/Plugin.test.js
@@ -1,0 +1,109 @@
+const test = require('ava');
+
+const Plugin = require('./Plugin');
+
+test.beforeEach((t) => {
+  t.context.plugin = new Plugin();
+  t.context.calls = 0;
+  t.context.opts = [];
+
+  t.context.plugin.register('test', (parameters, opts) => {
+    t.context.calls++;
+    t.context.opts.push(opts);
+    return 'TEST(' + parameters.join(',') + ')';
+  });
+});
+
+test('parse() set pos to character after end of tag and returns true', (t) => {
+  const state = [];
+  state.src = '{@test: hello}test';
+  state.pos = 0;
+
+  const result = t.context.plugin.parse(state);
+
+  t.is(state.src.indexOf('}') + 1, state.pos, 'did not set the pos to the character after the tag');
+  t.is(true, result, 'did not return true');
+});
+
+test('parse() does not change the position and returns false if it is not a tag', (t) => {
+  const state = [];
+  state.src = 'this is {a test';
+  state.pos = state.src.indexOf('{');
+
+  const result = t.context.plugin.parse(state);
+
+  t.is(state.pos, state.src.indexOf('{'), 'pos has been changed');
+  t.is(false, result, 'did not return true');
+});
+
+test('parse() handles tags inside tags', (t) => {
+  const state = [];
+  state.src = '{@test: {@test: hello}}';
+  state.pos = 0;
+
+  t.context.plugin.parse(state);
+
+  t.deepEqual(['test', ['', ['test', 'hello'], '']], state[0].content);
+});
+
+test('parse() handles tags next to tags inside tags', (t) => {
+  const state = [];
+  state.src = '{@test: {@test: hello}frog{@test: second}fin end}';
+  state.pos = 0;
+
+  t.context.plugin.parse(state);
+
+  t.deepEqual(['test', ['', ['test', 'hello'], 'frog', ['test', 'second'], 'fin'], 'end'], state[0].content);
+});
+
+test('render() calls the correct plugin', (t) => {
+  const tokens = [
+    {
+      type: 'rst',
+      level: 1,
+      content: [ 'test', 'ok' ]
+    }
+  ];
+
+  const opts = {};
+
+  const result = t.context.plugin.render(tokens, 0, opts);
+
+  t.is(1, t.context.calls, 'plugin was not called once');
+  t.is('TEST(ok)', result, 'rendered string was not as it should be');
+  t.is(opts, t.context.opts[0], 'opts was not passed to the plugin');
+});
+
+test('render() returns the tag if a plugin for the tag does not exist', (t) => {
+  const tokens = [
+    {
+      type: 'rst',
+      level: 1,
+      content: [ 'blah', 'ok' ]
+    }
+  ];
+
+  const opts = {};
+
+  const result = t.context.plugin.render(tokens, 0, opts);
+
+  t.is('{@blah: ok}', result, 'rendered string was not as it should be');
+});
+
+test('render() calls the plugins in plugins', (t) => {
+  const tokens = [
+    {
+      type: 'rst',
+      level: 1,
+      content: [ 'test', ['frog', ['test', 'awesome'], 'end'], 'ok' ]
+    }
+  ];
+
+  const opts = {};
+
+  const result = t.context.plugin.render(tokens, 0, opts);
+
+  t.is(2, t.context.calls, 'plugin was not called once');
+  t.is('TEST(frogTEST(awesome)end,ok)', result, 'rendered string was not as it should be');
+  t.is(opts, t.context.opts[0], 'opts was not passed to the plugin');
+});

--- a/lib/Plugin.test.js
+++ b/lib/Plugin.test.js
@@ -71,6 +71,26 @@ test('parse() handles parameterless tags', (t) => {
   t.deepEqual(['test'], state[0].content);
 });
 
+test('parse() handles escaped quotes a curly braces', (t) => {
+  const state = [];
+  state.src = '{@test: ok\\{ok ok\\"ok "ok\\"ok\\}"}';
+  state.pos = 0;
+
+  t.context.plugin.parse(state);
+
+  t.deepEqual(['test', 'ok{ok', 'ok"ok', 'ok"ok}'], state[0].content);
+});
+
+test('parse() handles ignores treats mulitple spaces as a single space between parameters', (t) => {
+  const state = [];
+  state.src = '{@test: to  this    end}';
+  state.pos = 0;
+
+  t.context.plugin.parse(state);
+
+  t.deepEqual(['test', 'to', 'this', 'end'], state[0].content);
+});
+
 test('render() calls the correct plugin', (t) => {
   const tokens = [
     {
@@ -191,7 +211,7 @@ test ('RST can be used with Remarkable', (t) => {
 test('RST works with Remarkable', (t) => {
   t.context.md.use(t.context.plugin.hook);
 
-  const result = t.context.md.render('string{@test}{@test:hello}end');
+  const result = t.context.md.render('string{@test}{@test:hello {@test: help  me} "enter\\"tain you"}end');
 
-  t.is('<p>stringTEST()TEST(hello)end</p>\n', result);
+  t.is('<p>stringTEST()TEST(hello,TEST(help,me),enter"tain you)end</p>\n', result);
 });

--- a/lib/Plugin.test.js
+++ b/lib/Plugin.test.js
@@ -60,6 +60,17 @@ test('parse() handles tags next to tags inside tags', (t) => {
   t.deepEqual(['test', ['', ['test', 'hello'], 'frog', ['test', 'second'], 'fin'], 'end'], state[0].content);
 });
 
+test('parse() handles parameterless tags', (t) => {
+  const state = [];
+  state.src = '{@test}frog';
+  state.pos = 0;
+
+  t.context.plugin.parse(state);
+
+  t.is(7, state.pos, 'did not move state position');
+  t.deepEqual(['test'], state[0].content);
+});
+
 test('render() calls the correct plugin', (t) => {
   const tokens = [
     {
@@ -75,6 +86,24 @@ test('render() calls the correct plugin', (t) => {
 
   t.is(1, t.context.calls, 'plugin was not called once');
   t.is('TEST(ok)', result, 'rendered string was not as it should be');
+  t.is(opts, t.context.opts[0], 'opts was not passed to the plugin');
+});
+
+test('render() calls the plugin with an empty array if no parameters', (t) => {
+  const tokens = [
+    {
+      type: 'rst',
+      level: 1,
+      content: [ 'test' ]
+    }
+  ];
+
+  const opts = {};
+
+  const result = t.context.plugin.render(tokens, 0, opts);
+
+  t.is(1, t.context.calls, 'plugin was not called once');
+  t.is('TEST()', result, 'rendered string was not as it should be');
   t.is(opts, t.context.opts[0], 'opts was not passed to the plugin');
 });
 
@@ -162,7 +191,7 @@ test ('RST can be used with Remarkable', (t) => {
 test('RST works with Remarkable', (t) => {
   t.context.md.use(t.context.plugin.hook);
 
-  const result = t.context.md.render('string{@test:hello}end');
+  const result = t.context.md.render('string{@test}{@test:hello}end');
 
-  t.is('<p>stringTEST(hello)end</p>\n', result);
+  t.is('<p>stringTEST()TEST(hello)end</p>\n', result);
 });

--- a/lib/plugins/codepen.js
+++ b/lib/plugins/codepen.js
@@ -1,22 +1,22 @@
 module.exports = function (code, opts) {
-	var themeId = opts.codepen.themeId;
-	var height = opts.codepen.height;
-	var defaultTab = opts.codepen.defaultTab;
+  var themeId = opts.codepen.themeId;
+  var height = opts.codepen.height;
+  var defaultTab = opts.codepen.defaultTab;
 
   code = code[0];
 
-	return "<iframe " +
-		"height='"+height+"' " +
-		"scrolling='no' " +
-		"src='//codepen.io/Commander-lol/embed/preview/" + code + "/?height="+height+"&theme-id="+themeId+"&default-tab="+defaultTab+"&embed-version=2' " +
-		"frameborder='no' " +
-		"allowtransparency='true' " +
-		"allowfullscreen='true' " +
-		"style='width: 100%;'>" +
-		"See the Pen" +
-		"<a href='http://codepen.io/Commander-lol/pen/" + code + "/'>" +
-		"" + code + "" +
-		"</a>" +
-		"by Louis Capitanchik (<a href='http://codepen.io/Commander-lol'>@Commander-lol</a>)" +
-		"on <a href='http://codepen.io'>CodePen</a></iframe>"
+  return "<iframe " +
+    "height='"+height+"' " +
+    "scrolling='no' " +
+    "src='//codepen.io/Commander-lol/embed/preview/" + code + "/?height="+height+"&theme-id="+themeId+"&default-tab="+defaultTab+"&embed-version=2' " +
+    "frameborder='no' " +
+    "allowtransparency='true' " +
+    "allowfullscreen='true' " +
+    "style='width: 100%;'>" +
+    "See the Pen" +
+    "<a href='http://codepen.io/Commander-lol/pen/" + code + "/'>" +
+    "" + code + "" +
+    "</a>" +
+    "by Louis Capitanchik (<a href='http://codepen.io/Commander-lol'>@Commander-lol</a>)" +
+    "on <a href='http://codepen.io'>CodePen</a></iframe>"
 }

--- a/lib/plugins/codepen.js
+++ b/lib/plugins/codepen.js
@@ -3,6 +3,8 @@ module.exports = function (code, opts) {
 	var height = opts.codepen.height;
 	var defaultTab = opts.codepen.defaultTab;
 
+  code = code[0];
+
 	return "<iframe " +
 		"height='"+height+"' " +
 		"scrolling='no' " +

--- a/lib/plugins/youtube.js
+++ b/lib/plugins/youtube.js
@@ -1,9 +1,11 @@
 module.exports = function(code) {
   code = code[0];
 
-	if (code.startsWith('https://')) {
-		return '<iframe type="text/html" src="' + code + '" frameborder="0"></iframe>'
+  if (code.startsWith('https://')) {
+    return '<iframe type="text/html" src="' + code
+        + '" frameborder="0"></iframe>';
 
-	}
-	return '<iframe type="text/html" src="https://www.youtube.com/embed/' + code + '" frameborder="0"></iframe>'
+  }
+  return '<iframe type="text/html" src="https://www.youtube.com/embed/'
+      + code + '" frameborder="0"></iframe>';
 }

--- a/lib/plugins/youtube.js
+++ b/lib/plugins/youtube.js
@@ -1,4 +1,6 @@
 module.exports = function(code) {
+  code = code[0];
+
 	if (code.startsWith('https://')) {
 		return '<iframe type="text/html" src="' + code + '" frameborder="0"></iframe>'
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "tonicExampleFilename": "tonic.js",
   "homepage": "https://github.com/Commander-lol/remarkably-simple-tags#readme",
   "devDependencies": {
-    "ava": "^0.25.0"
+    "ava": "^0.25.0",
+    "remarkable": "^1.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "remarkably-simple-stags",
+  "name": "remarkably-simple-tags",
   "version": "1.0.0",
   "description": "Extensible Remarkable plugin for embedding content in markdown",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "url": "https://github.com/Commander-lol/remarkable-embed/issues"
   },
   "tonicExampleFilename": "tonic.js",
-  "homepage": "https://github.com/Commander-lol/remarkable-embed#readme"
+  "homepage": "https://github.com/Commander-lol/remarkable-embed#readme",
+  "devDependencies": {
+    "ava": "^0.25.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "remarkable-embed",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Extensible Remarkable plugin for embedding content in markdown",
   "main": "index.js",
   "scripts": {
-    "test": "make test"
+    "test": "ava"
   },
   "keywords": [
     "remarkable",
@@ -14,6 +14,9 @@
     "plugin"
   ],
   "author": "Louis Capitanchik <contact@louiscap.co>",
+  "contributors": [
+    "Jack Farley <or4e3dsw@bytes.nz> (https://bytes.nz)"
+  ],
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "remarkable-embed",
-  "version": "0.5.0",
+  "name": "remarkably-simple-stags",
+  "version": "1.0.0",
   "description": "Extensible Remarkable plugin for embedding content in markdown",
   "main": "index.js",
   "scripts": {
@@ -13,20 +13,27 @@
     "extension",
     "plugin"
   ],
-  "author": "Louis Capitanchik <contact@louiscap.co>",
+  "author": {
+    "name": "Jack Farley",
+    "email": "or4e3dsw@bytes.nz",
+    "url": "https://bytes.nz)"
+  },
   "contributors": [
-    "Jack Farley <or4e3dsw@bytes.nz> (https://bytes.nz)"
+    {
+      "name": "Louis Capitanchik",
+      "email": "contact@louiscap.co"
+    }
   ],
-  "license": "BSD-3-Clause",
+  "license": "GPL-3.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Commander-lol/remarkable-embed.git"
+    "url": "git+https://github.com/Commander-lol/remarkably-simple-tags.git"
   },
   "bugs": {
-    "url": "https://github.com/Commander-lol/remarkable-embed/issues"
+    "url": "https://github.com/Commander-lol/remarkably-simple-tags/issues"
   },
   "tonicExampleFilename": "tonic.js",
-  "homepage": "https://github.com/Commander-lol/remarkable-embed#readme",
+  "homepage": "https://github.com/Commander-lol/remarkably-simple-tags#readme",
   "devDependencies": {
     "ava": "^0.25.0"
   }

--- a/tonic.js
+++ b/tonic.js
@@ -1,22 +1,22 @@
 const Remarkable = require('remarkable');
-const reEmbed = require('remarkable-embed');
+const RST = require('remarkably-simple-tags');
 
 const md = new Remarkable('full', {
-	codepen: {
-		defaultTab: 'result',
-		height: 256,
-		themeId: '0'
-	}
+  codepen: {
+    defaultTab: 'result',
+    height: 256,
+    themeId: '0'
+  }
 });
 
-const embed = new reEmbed.Plugin;
+const rst = new RST.Plugin();
 
-embed.register(reEmbed.extensions);
+rst.register(RST.extensions);
 
-md.use(embed.hook);
+md.use(rst.hook);
 
 console.log(md.render(`
-### This is remarkable embed
+### This is remarkably-simple-tags
 
 Haha, this is a super cool video: {@youtube: dQw4w9WgXcQ}
 


### PR DESCRIPTION
Not sure if you are keen to extend the functionality, but I have extended it so that you can pass multiple parameters in the tag if you register the plugin with the multiple option.

```javascript
Plugin.register('plugin', (parameters, opts) => 'something great', true)
```
```
{@plugin: parameter1 parameter2 parameter3}
```

I have also added tests using ava and made it so you can put tags inside of tags and use quotes, for instance:
```
{@image: {@static: some/image.png} "Some caption for the image"}
```